### PR TITLE
Inject the AppKernel into the SymfonyClient

### DIFF
--- a/Client/SymfonyClient.php
+++ b/Client/SymfonyClient.php
@@ -65,10 +65,12 @@ class SymfonyClient implements ClientInterface
      */
     public function __construct(
         SessionInterface $session,
-        EnvironmentBuilderInterface $environmentBuilder = null
+        EnvironmentBuilderInterface $environmentBuilder = null,
+        \AppKernel $kernel = null
     ) {
         $this->session = $session;
         $this->environmentBuilder = $environmentBuilder;
+        $this->kernel = $kernel;
     }
 
     /**
@@ -78,7 +80,6 @@ class SymfonyClient implements ClientInterface
      */
     public function buildClient()
     {
-        $this->kernel = new \AppKernel('test', false);
         $this->kernel->boot();
         $this->session->clear();
 

--- a/Resources/config/clients.yml
+++ b/Resources/config/clients.yml
@@ -8,3 +8,11 @@ services:
         arguments:
             - @session
             - @visitor.environment_builder
+            - @visithor.client.app_kernel
+
+    visithor.client.app_kernel:
+        public: false
+        class: AppKernel
+        arguments:
+            - "%kernel.environment%"
+            - "%kernel.debug%"


### PR DESCRIPTION
Inject a custom AppKernel into the SymfonyClient.
This way the commandline's environment and debug paramters are used, instead of hardcoded 'test' environment and no-debug.
